### PR TITLE
Supress test name warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub fn test_with(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         let expanded = quote!(
             #[test]
+            #[allow(non_snake_case)]
             fn #fun_full_ident() {
                 #name::<#a>();
             }


### PR DESCRIPTION
Without this the macro reports a warning about the generated test names (because they have double underscore and capitals in them).